### PR TITLE
Fixing Clerk publishableKey error in Docker builds-28-dia5.md

### DIFF
--- a/community_contributions/fixing-docker-clerk-28-dia5.md
+++ b/community_contributions/fixing-docker-clerk-28-dia5.md
@@ -1,0 +1,47 @@
+# Fixing Missing Environment Variables in Docker Builds (Clerk + Next.js)
+
+## Context
+During `next build` inside a Docker multi-stage image, I got:
+
+Error: @clerk/clerk-react: Missing publishableKey.
+Error occurred prerendering page “/”.
+Export encountered an error on /, exiting the build.
+
+Root cause: at build/prerender time, Next.js needs **both** Clerk keys in the environment:
+- Client: `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+- Server/SSR: `CLERK_PUBLISHABLE_KEY`
+
+If they’re not present **before** `npm run build`, the build fails.
+
+---
+
+## Solution
+
+### 1) Dockerfile (frontend builder stage)
+Expose the keys as ENV **before** `npm run build`:
+
+```dockerfile
+FROM node:22-alpine AS frontend-builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+ENV CLERK_PUBLISHABLE_KEY=${CLERK_PUBLISHABLE_KEY}
+
+RUN npm run build
+
+Do not bake CLERK_SECRET_KEY at build time (secrets only in runtime/backends).
+
+## Build args usage
+
+```bash
+docker build \
+  --platform linux/amd64 \
+  --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" \
+  --build-arg CLERK_PUBLISHABLE_KEY="$CLERK_PUBLISHABLE_KEY" \
+  -t consultation-app .


### PR DESCRIPTION
This contribution documents a issue when building Next.js apps with Clerk inside Docker.

- Problem: Next.js build fails due to missing publishableKey during prerender/SSR.
- Cause: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY (client) and CLERK_PUBLISHABLE_KEY (server) are not present in the build stage.
- Solution: Provide both as build args and expose them as ENV before `npm run build`. Add runtime envs and mark pages using auth as dynamic when needed.
- File: community_contributions/fixing-docker-clerk.md

Thanks for reviewing!