### PR TITLE
Update day2.md

### DIFF
--- a/week2/day2.md
+++ b/week2/day2.md
@@ -491,6 +491,8 @@ def main():
             "docker",
             "run",
             "--rm",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
             "-v",
             f"{os.getcwd()}:/var/task",
             "--platform",


### PR DESCRIPTION
By default docker may run as the root user on some machines which causes the initial rmtree and remove to fail when rebuilding in day 3 with bedrock support.