### PR TITLE
Fix twin.tsx to auto-focus cursor in input window

### DIFF
--- a/community_contributions/twin_tsx_auto_focus/twin.tsx
+++ b/community_contributions/twin_tsx_auto_focus/twin.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Send, Bot, User } from 'lucide-react';
+
+interface Message {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: Date;
+}
+
+export default function Twin() {
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [input, setInput] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [sessionId, setSessionId] = useState<string>('');
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null); // Added ref for input
+
+    const scrollToBottom = () => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    };
+
+    useEffect(() => {
+        scrollToBottom();
+    }, [messages]);
+
+    // Auto-focus input on first render
+    useEffect(() => {
+        inputRef.current?.focus();
+    }, []);
+
+    const sendMessage = async () => {
+        if (!input.trim() || isLoading) return;
+
+        const userMessage: Message = {
+            id: Date.now().toString(),
+            role: 'user',
+            content: input,
+            timestamp: new Date(),
+        };
+
+        setMessages(prev => [...prev, userMessage]);
+        setInput('');
+        setIsLoading(true);
+
+        try {
+            const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/chat`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    message: input,
+                    session_id: sessionId || undefined,
+                }),
+            });
+
+            if (!response.ok) throw new Error('Failed to send message');
+
+            const data = await response.json();
+
+            if (!sessionId) {
+                setSessionId(data.session_id);
+            }
+
+            const assistantMessage: Message = {
+                id: (Date.now() + 1).toString(),
+                role: 'assistant',
+                content: data.response,
+                timestamp: new Date(),
+            };
+
+            setMessages(prev => [...prev, assistantMessage]);
+        } catch (error) {
+            console.error('Error:', error);
+            // Add error message
+            const errorMessage: Message = {
+                id: (Date.now() + 1).toString(),
+                role: 'assistant',
+                content: 'Sorry, I encountered an error. Please try again.',
+                timestamp: new Date(),
+            };
+            setMessages(prev => [...prev, errorMessage]);
+        } finally {
+            setIsLoading(false);
+            inputRef.current?.focus(); // Refocus input after sending message
+        }
+    };
+
+    const handleKeyPress = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendMessage();
+        }
+    };
+
+    return (
+        <div className="flex flex-col h-full bg-gray-50 rounded-lg shadow-lg">
+            {/* Header */}
+            <div className="bg-gradient-to-r from-slate-700 to-slate-800 text-white p-4 rounded-t-lg">
+                <h2 className="text-xl font-semibold flex items-center gap-2">
+                    <Bot className="w-6 h-6" />
+                    AI Digital Twin
+                </h2>
+                <p className="text-sm text-slate-300 mt-1">Your AI course companion</p>
+            </div>
+
+            {/* Messages */}
+            <div className="flex-1 overflow-y-auto p-4 space-y-4">
+                {messages.length === 0 && (
+                    <div className="text-center text-gray-500 mt-8">
+                        <Bot className="w-12 h-12 mx-auto mb-3 text-gray-400" />
+                        <p>Hello! I&apos;m your Digital Twin.</p>
+                        <p className="text-sm mt-2">Ask me anything about AI deployment!</p>
+                    </div>
+                )}
+
+                {messages.map((message) => (
+                    <div
+                        key={message.id}
+                        className={`flex gap-3 ${
+                            message.role === 'user' ? 'justify-end' : 'justify-start'
+                        }`}
+                    >
+                        {message.role === 'assistant' && (
+                            <div className="flex-shrink-0">
+                                <div className="w-8 h-8 bg-slate-700 rounded-full flex items-center justify-center">
+                                    <Bot className="w-5 h-5 text-white" />
+                                </div>
+                            </div>
+                        )}
+
+                        <div
+                            className={`max-w-[70%] rounded-lg p-3 ${
+                                message.role === 'user'
+                                    ? 'bg-slate-700 text-white'
+                                    : 'bg-white border border-gray-200 text-gray-800'
+                            }`}
+                        >
+                            <p className="whitespace-pre-wrap">{message.content}</p>
+                            <p
+                                className={`text-xs mt-1 ${
+                                    message.role === 'user' ? 'text-slate-300' : 'text-gray-500'
+                                }`}
+                            >
+                                {message.timestamp.toLocaleTimeString()}
+                            </p>
+                        </div>
+
+                        {message.role === 'user' && (
+                            <div className="flex-shrink-0">
+                                <div className="w-8 h-8 bg-gray-600 rounded-full flex items-center justify-center">
+                                    <User className="w-5 h-5 text-white" />
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                ))}
+
+                {isLoading && (
+                    <div className="flex gap-3 justify-start">
+                        <div className="flex-shrink-0">
+                            <div className="w-8 h-8 bg-slate-700 rounded-full flex items-center justify-center">
+                                <Bot className="w-5 h-5 text-white" />
+                            </div>
+                        </div>
+                        <div className="bg-white border border-gray-200 rounded-lg p-3">
+                            <div className="flex space-x-2">
+                                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
+                                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce delay-100" />
+                                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce delay-200" />
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                <div ref={messagesEndRef} />
+            </div>
+
+            {/* Input */}
+            <div className="border-t border-gray-200 p-4 bg-white rounded-b-lg">
+                <div className="flex gap-2">
+                    <input
+                        ref={inputRef}   // Add this line
+                        type="text"
+                        value={input}
+                        onChange={(e) => setInput(e.target.value)}
+                        onKeyDown={handleKeyPress}
+                        placeholder="Type your message..."
+                        className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-600 focus:border-transparent text-gray-800"
+                        /* disabled={isLoading} */
+                    />
+                    <button
+                        onClick={sendMessage}
+                        disabled={!input.trim() || isLoading}
+                        className="px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                        <Send className="w-5 h-5" />
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
**This is the digital twin for AI in Production**

Was getting frustrated with having to click on the prompt window, so have made changes to twin.tsx such that 
1. The cursor will automatically appear in the message box when the chatt loads.
2. After pressing Enter or clicking Send, the cursor will jump back into the box ready for the next message.

**Changes (as per chatGPT):**
Add a useRef for the input element and a useEffect to focus it when the component mounts:
// Added this near the top with other refs
const inputRef = useRef<HTMLInputElement>(null);

// Added after scrollToBottom: Auto-focus input on first render
useEffect(() => {
    inputRef.current?.focus();
}, []);

// then attach the ref to top of input
 ref={inputRef}   //  Add this line
 
To regain focus automatically after sending a message, add below line in sendMessage (towards the end)
 inputRef.current?.focus(); // Refocus input after sending message
 
 // commented this line in Input as the'browser momentarily removes it from focus when it becomes disabled' 
 disabled={isLoading}