### PR TITLE
Week 2: Igniters: Add week 2 contribution: Personal Digital Twin on AWS

### DIFF
--- a/community_contributions/haastrupea/week2.md
+++ b/community_contributions/haastrupea/week2.md
@@ -1,0 +1,13 @@
+Digital Twin on AWS
+I built a personal digital twin (my own facts, LinkedIn/summary notes, and style prompts) as a small serverless stack on AWS: a FastAPI backend wrapped with Mangum for AWS Lambda, exposed through API Gateway, with session-based chat memory stored either locally (dev) or in S3 when enabled. The LLM calls go through OpenRouter (e.g. gpt-4o-mini) using a system prompt assembled from my context / resources.
+
+The Next.js frontend is a simple chat UI that talks to the deployed API. I package the Lambda artifact with a Docker-based deploy.py script (Lambda Python 3.12–compatible dependencies and a zip for upload), which matches a manual or console-style deploy path for validating the stack end-to-end.
+
+(Optional—only if accurate for you: I codified infrastructure with Terraform / wired GitHub Actions for CI/CD…)
+
+GitHub
+https://github.com/haastrupea/twins-aws-deploy
+
+Live URL
+https://d12ojqcn1s89o3.cloudfront.net/
+


### PR DESCRIPTION
This pull request adds a new community contribution describing the implementation of a personal digital twin using AWS serverless technologies. The summary details the architecture, deployment process, and provides links to the GitHub repository and live application.

New community contribution:

* Added a write-up in `community_contributions/haastrupea/week2.md` detailing the creation of a personal digital twin on AWS, including a FastAPI backend (deployed with AWS Lambda and Mangum), session-based chat memory, OpenRouter LLM integration, and a Next.js frontend. The contribution also describes the deployment process and provides GitHub and live demo links.

Live URL: https://d12ojqcn1s89o3.cloudfront.net/

Screenshot

<img width="1273" height="665" alt="image" src="https://github.com/user-attachments/assets/d8736a20-0d1f-4bde-b3df-f4baf12164d2" />

@iamumarjaved