### PR TITLE
Igniters - Week 4 - Alex financial planner multi agent on GCP

### DIFF
--- a/community_contributions/a3_igniters_amitb/week4_final_exercise.md
+++ b/community_contributions/a3_igniters_amitb/week4_final_exercise.md
@@ -1,0 +1,65 @@
+# Week 4 Final Exercise - Alex: AI Financial Planner (Multi-Agent)
+
+**Repository:** https://github.com/SectumPsempra/production/tree/week3-exercise-local/alex_financial_planner/backend/agents  
+**Deployed App:** https://alex-frontend-ajg5nndceq-uc.a.run.app
+
+---
+
+## What is Being Built
+
+Alex is a cloud-native AI financial planning assistant built on a **multi-agent architecture**. Users sign in, register their investment accounts and holdings, and trigger a portfolio analysis. Rather than a single LLM call, the work is broken across five specialised agents that run concurrently, each with a focused responsibility. The results are stitched together by a Planner agent and written back to the database for the frontend to display.
+
+A sixth agent - the Researcher - runs on a separate Cloud Run service on a scheduled basis, autonomously browsing the web and writing market research into a vector knowledge base. That knowledge base is retrieved at analysis time to ground the report in current financial context.
+
+---
+
+## The Six Agents
+
+| Agent | Responsibility |
+|---|---|
+| **Planner** | Orchestrates the pipeline: loads portfolio data, fans out to the four specialist agents in parallel, merges results, writes the completed job to the database |
+| **Instrument Tagger** | Classifies each holding by asset class, sector, and region using an LLM with structured output (Pydantic schema) |
+| **Report Writer** | Generates the full written portfolio analysis, pulling relevant context from the pgvector knowledge base via semantic search |
+| **Chart Maker** | Produces structured JSON describing allocation charts (asset class, region, sector breakdowns) ready for the frontend to render |
+| **Retirement Specialist** | Projects retirement income based on current portfolio value, expected return, years to retirement, and withdrawal rate |
+| **Researcher** | Runs on a schedule (every 2 hours via Cloud Scheduler), searches the web for relevant financial news, and stores embeddings into the knowledge base for retrieval by the Report Writer |
+
+---
+
+## Architecture and Services
+
+| Layer | GCP Service Used | AWS Equivalent |
+|---|---|---|
+| Frontend (Next.js) | Cloud Run | Elastic Beanstalk / App Runner |
+| REST API (FastAPI) | Cloud Run | API Gateway + Lambda / App Runner |
+| Agents Worker - 5 agents (FastAPI) | Cloud Run | ECS Fargate |
+| Researcher Agent (FastAPI) | Cloud Run (separate service) | ECS Fargate |
+| Job Queue | Cloud Tasks | SQS |
+| Scheduled Research Trigger | Cloud Scheduler | EventBridge Scheduler |
+| Relational Database | Cloud SQL (PostgreSQL) | RDS PostgreSQL |
+| Vector Store | pgvector extension on Cloud SQL | RDS + pgvector or OpenSearch |
+| Secrets | Secret Manager | Secrets Manager |
+| Container Registry | Artifact Registry | ECR |
+| Authentication | Clerk (third-party, same on both) | Cognito |
+| LLM Calls | OpenRouter API | Amazon Bedrock |
+| Embeddings | OpenAI text-embedding-3-small | Amazon Titan Embeddings |
+
+---
+
+## How it Works End-to-End
+
+1. The user logs in via Clerk and views their portfolio on the Next.js frontend (Cloud Run).
+2. They click "Run Analysis". The frontend calls the FastAPI REST API.
+3. The API creates a `pending` job record in Cloud SQL, then enqueues a task to **Cloud Tasks** (analogous to SQS). The response returns immediately with the job ID.
+4. Cloud Tasks invokes the **Agents Worker** service with an OIDC-authenticated HTTP POST.
+5. The **Planner** agent loads the user's full portfolio from Cloud SQL, then fans out to the four specialist agents concurrently using `asyncio.gather`:
+   - Instrument Tagger classifies all holdings.
+   - Report Writer retrieves relevant research from the pgvector knowledge base via cosine similarity search, then writes the full analysis.
+   - Chart Maker generates chart-ready JSON for the UI.
+   - Retirement Specialist calculates projected income.
+6. The Planner merges all results and writes them back to the `jobs` table with status `completed`.
+7. The frontend polls the API every 4 seconds until the job is complete, then renders the report, charts, and retirement projection.
+
+In parallel, the **Researcher** service runs every 2 hours via **Cloud Scheduler**. It searches financial news sources, scrapes article text, generates embeddings via the OpenAI embeddings API, and stores them in the `knowledge_base` table - keeping the Report Writer's context current without any manual intervention.
+
+All six services are containerised with Docker (`linux/amd64` for Cloud Run compatibility) and the entire infrastructure is defined in Terraform across four modules: database, researcher, agents, and frontend+API.


### PR DESCRIPTION
### Summary
- Adds alex_financial_planner/, a full-stack multi-agent AI financial planning application deployed on GCP using OpenRouter for all LLM calls
- Implements a six-agent pipeline: Planner, Instrument Tagger, Report Writer, Chart Maker, Retirement Specialist, and an autonomous Researcher that runs on a schedule
- Deploys all services to Cloud Run with full infrastructure managed in Terraform

### Details

#### 1. Backend (backend/)
- database/ — Cloud SQL PostgreSQL schema with pgvector for semantic search, asyncpg client with lazy connection pooling
- agents/ — FastAPI service hosting five specialised agents; the Planner fans them out concurrently via asyncio.gather and writes results back to the jobs table
- researcher/ — Separate FastAPI service that autonomously searches for financial news, generates embeddings, and stores them in the knowledge base
- api/ — User-facing REST API handling auth (Clerk JWT), account/position CRUD, job triggering via Cloud Tasks, and job status polling

#### 2. Frontend (frontend/)
- Next.js app with Clerk authentication, portfolio management pages, and a polling-based analysis results view with charts

#### 3. Infrastructure (terraform/)
- Four Terraform modules: Cloud SQL + service account, Researcher + Cloud Scheduler, Agents + Cloud Tasks queue, API + Frontend Cloud Run services

#### 4. Deployment (deploy.sh)
- Single idempotent script that enables APIs, provisions infrastructure, runs DB migrations via Cloud SQL Auth Proxy, builds and pushes linux/amd64 Docker images, and deploys all services

### Screenshots

<img width="1395" height="675" alt="Screenshot 2026-04-30 at 2 37 44 AM" src="https://github.com/user-attachments/assets/a223c1ce-f234-4339-856c-499f0dfdccb0" />
<img width="1251" height="990" alt="Screenshot 2026-04-30 at 2 38 05 AM" src="https://github.com/user-attachments/assets/f52aab60-51ef-444b-be3f-499714e9faef" />
<img width="1251" height="990" alt="Screenshot 2026-04-30 at 2 38 13 AM" src="https://github.com/user-attachments/assets/3da8cc04-d430-413f-83de-36d4b334f8a5" />
<img width="1251" height="872" alt="Screenshot 2026-04-30 at 2 38 32 AM" src="https://github.com/user-attachments/assets/6fe873f4-e410-477b-8f4e-37e8212a849c" />

_@iamumarjaved please review, as week 4 assignment is a multi-agent extension of the week 3 exercise the repo points to the same url where initially a single agent was developed and then it was further enhanced with multiple agents, I have kept a single deployment resource to save costs on GCP._ Thanks!