### PR TITLE
Fix AWS Lambda container compatibility

### DIFF
--- a/week1/day5.md
+++ b/week1/day5.md
@@ -381,64 +381,69 @@ Docker lets us package everything into a single container that runs anywhere.
 Create `Dockerfile` in your project root:
 
 ```dockerfile
-# Stage 1: Build the Next.js static files
-FROM node:22-alpine AS frontend-builder
+
+# =========================
+# Stage 1: Build Next.js frontend
+# =========================
+FROM --platform=linux/amd64 node:22-alpine AS frontend-builder
 
 WORKDIR /app
 
-# Copy package files first (for better caching)
+# Copy package files first for caching
 COPY package*.json ./
+
+# Install dependencies
 RUN npm ci
 
-# Copy all frontend files
+# Copy project files
 COPY . .
 
-# Build argument for Clerk public key
+# Clerk public key
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
-# Note: Docker may warn about "secrets in ARG/ENV" - this is OK!
-# The NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is meant to be public (it starts with pk_)
-
-# Build the Next.js app (creates 'out' directory with static files)
+# Build Next.js static export
 RUN npm run build
 
-# Stage 2: Create the final Python container
-FROM python:3.12-slim
+
+# =========================
+# Stage 2: Python + FastAPI + Lambda
+# =========================
+FROM --platform=linux/amd64 python:3.12-slim
 
 WORKDIR /app
 
-# --- Lambda Web Adapter additions (the only changes vs. the video's Dockerfile) ---
-# Drops a Lambda extension binary into /opt/extensions. The binary is inert
-# unless invoked by the Lambda runtime, so local `docker run` is unaffected.
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt/extensions/lambda-adapter
+# Install Lambda Web Adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 \
+    /lambda-adapter \
+    /opt/extensions/lambda-adapter
 
-# Tell the adapter which port FastAPI listens on
+# Environment variables
 ENV PORT=8000
-
-# Enable Lambda response streaming (required so SSE / streaming endpoints work end-to-end)
 ENV AWS_LWA_INVOKE_MODE=response_stream
-# --- end of Lambda Web Adapter additions ---
 
 # Install Python dependencies
 COPY requirements.txt .
+
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the FastAPI server
+# Copy FastAPI server
 COPY api/server.py .
 
-# Copy the Next.js static export from builder stage
+# Copy Next.js static files
 COPY --from=frontend-builder /app/out ./static
 
-# Health check (used during local Docker testing; Lambda does not call it)
+# Healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
 
-# Expose port 8000 (FastAPI will serve everything)
+# Expose FastAPI port
 EXPOSE 8000
 
-# Start the FastAPI server
+# Start FastAPI server
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]
+
+
 ```
 
 ### Step 2: Create .dockerignore


### PR DESCRIPTION
## Fix AWS Lambda container deployment compatibility

### Problem

Deployment of the container image to AWS Lambda failed with the following error:

```text
The image manifest, config or layer media type for the source image is not supported.
```

This was caused by Docker image compatibility and architecture issues when building/pushing the container image for Lambda.

### Changes Made

#### Dockerfile updates

* Added explicit platform targeting (`linux/amd64`) to both build stages
* Updated AWS Lambda Web Adapter image version
* Ensured consistent architecture across all container stages

#### Build process updates

* Standardized Docker build process for Lambda-compatible manifests
* Disabled BuildKit during builds to avoid OCI manifest incompatibilities with AWS Lambda

### Updated Dockerfile changes

```dockerfile
FROM --platform=linux/amd64 node:22-alpine AS frontend-builder
```

```dockerfile
FROM --platform=linux/amd64 python:3.12-slim
```

```dockerfile
COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 \
    /lambda-adapter \
    /opt/extensions/lambda-adapter
```

### Impact

* Fixes Lambda container deployment failures
* Ensures compatibility with AWS Lambda container runtime
* Maintains existing local Docker workflow
* Preserves FastAPI + Next.js deployment architecture

### Deployment Notes

Builds should be run using:

```powershell
$env:DOCKER_BUILDKIT=0
```

before executing the Docker build command.
