### PR TITLE
Remove custom error response for 404

### DIFF
--- a/week2/day4.md
+++ b/week2/day4.md
@@ -558,12 +558,6 @@ resource "aws_cloudfront_distribution" "main" {
       restriction_type = "none"
     }
   }
-
-  custom_error_response {
-    error_code         = 404
-    response_code      = 200
-    response_page_path = "/index.html"
-  }
 }
 
 # Optional: Custom domain configuration (only created when use_custom_domain = true)


### PR DESCRIPTION
This piece breaks the avatar check later on. The frontend S3 is configured to return 404.html and 404 on error. This configuration would turn that 404 and 404.html to 200 and index.html. As a result the avatar check would always succeed and would show invalid avatar picture, instead of the default Bot tag, if one is not available.