### PR TITLE
Change IAM role from ReadOnly to FullAccess

### DIFF
--- a/week2/day2.md
+++ b/week2/day2.md
@@ -441,7 +441,7 @@ Replace `your_aws_account_id` with your actual AWS account ID (12 digits).
    - `AmazonS3FullAccess` - For S3 bucket operations
    - `AmazonAPIGatewayAdministrator` - For API Gateway
    - `CloudFrontFullAccess` - For CloudFront distribution
-   - `IAMReadOnlyAccess` - To view roles
+   - `IAMFullAccess` - To view roles
    - `AmazonDynamoDBFullAccess_v2` - Needed on Day 4
 5. Click **Create group**
 


### PR DESCRIPTION
Why is this change needed?
Following the previous guide with only IAMReadOnlyAccess results in an authorization error during deployment/setup when creating AWS Lambda or API Gateway service roles:

User: arn:aws:iam::<account-id>:user/aiengineer is not authorized to perform: iam:CreateRole on resource: ...

Changes Made：
Updated Step 3 instructions in the README / deployment guide to include IAMFullAccess for the TwinAccess IAM user group to allow creating and attaching policies to execution roles.

Testing：
Verified that adding the IAM permission resolves the iam:CreateRole AccessDenied error and allows successful deployment.