### PR TITLE
docs: disable Docker provenance in day5 build examples

### DIFF
--- a/week1/day5.md
+++ b/week1/day5.md
@@ -610,6 +610,7 @@ aws ecr get-login-password --region $DEFAULT_AWS_REGION | docker login --usernam
 # 2. Build for Linux/AMD64 (CRITICAL for Apple Silicon Macs!)
 docker build \
   --platform linux/amd64 \
+  --provenance=false \
   --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" \
   -t consultation-app .
 
@@ -628,6 +629,7 @@ aws ecr get-login-password --region $env:DEFAULT_AWS_REGION | docker login --use
 # 2. Build for Linux/AMD64
 docker build `
   --platform linux/amd64 `
+  --provenance=false `
   --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$env:NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" `
   -t consultation-app .
 


### PR DESCRIPTION
Adds `--provenance=false` to the `docker build` commands in `week1/day5.md` (both the macOS/Linux and PowerShell variants).

This resolves an issue raised on video #29 of Ed's Udemy course. By default, Docker buildx attaches provenance attestations, which makes the pushed ECR artifact a multi-arch manifest list rather than a plain image manifest. AWS Lambda container images do not support a manifest list, so creating/updating the function from that image fails.

Thanks to user Shravan for the fix.