### PR TITLE
Increase reserved concurrency from 2 to 4

### DIFF
--- a/week1/day5.md
+++ b/week1/day5.md
@@ -498,7 +498,7 @@ docker build `
   -t consultation-app .
 ```
 
-This will take 2-3 minutes the first time.  
+This will take 2-3 minutes the first time.
 
 Windows people: if you get an error `The image manifest, config or layer media type for the source image [...] is not supported` then please go to Docker Desktop -> Settings -> General and make sure that "Use containerd for pulling and storing images checkbox" is NOT checked. Thank you Muhammad T. for this pro tip..
 
@@ -682,14 +682,14 @@ Now configure resources and environment variables.
    - **Timeout**: `5 min 0 sec` (`300` seconds) — long enough for the longest expected OpenAI streaming response
 4. Click **Save**
 
-#### Cap Concurrency at 2
+#### Cap Concurrency at 4
 
-By default, Lambda will scale your function out to many concurrent containers under load. For a course project, you want a hard cap so a runaway loop or a bot can't rack up usage. We'll set **Reserved Concurrency** to `2` — meaning at most 2 containers will ever run at the same time. Anything beyond that will be throttled with HTTP 429 until one finishes.
+By default, Lambda will scale your function out to many concurrent containers under load. For a course project, you want a hard cap so a runaway loop or a bot can't rack up usage. We'll set **Reserved Concurrency** to `4` — meaning at most 4 containers will ever run at the same time. Anything beyond that will be throttled with HTTP 429 until one finishes.
 
 5. Still in the **Configuration** tab, click **Concurrency and recursion detection** (left side)
 6. On the **Concurrency** card, click **Edit**
 7. Select **Reserve concurrency**
-8. Enter `2` for **Reserved concurrency**
+8. Enter `4` for **Reserved concurrency**
 9. Click **Save**
 
 > **Important — do NOT touch Provisioned concurrency.** That's a separate, paid feature on a different card on the same page that pre-warms containers and **costs money even when idle**. We only want **Reserved** concurrency, which is free and just acts as a ceiling. Leave Provisioned concurrency alone.


### PR DESCRIPTION
  ## Summary

  Increases the AWS Lambda function's Reserved Concurrency configuration from 2 to 4 to prevent request throttling during initial page loads.

  ## Problem

  When deployed to AWS Lambda, the application experienced the following issues on page load:

  • The Clerk authentication components (Sign In and Start Free Trial buttons) failed to render.
  • The browser console reported multiple 429 Too Many Requests errors for static JavaScript chunks `/_next/static/chunks/*`.

  ## Root Cause

  The browser generates multiple parallel HTTP requests for JS/CSS chunks when a user opens the web app.

  With Reserved Concurrency set to 2, AWS Lambda capped maximum concurrent executions at 2. Additional incoming parallel requests were immediately rejected by AWS with 429 Too Many Requests. This blocked critical client-side bundles
  (including @clerk/nextjs), causing React hydration to fail and preventing auth UI elements from rendering.

  ## Solution & Impact

  Increasing reserved concurrency to 4 provides sufficient parallel execution throughput for static file requests (which complete in milliseconds) to clear without triggering AWS throttling.

  • ✅ Resolves 429 Too Many Requests errors on static asset fetches.
  • ✅ Restores normal rendering of Clerk Sign In and Start Free Trial buttons.

  ## Verification / Testing

  [✓] Verified deployment on AWS Lambda.
  [✓] Confirmed Sign In and Start Free Trial buttons render as expected on initial page load.
  [✓] Confirmed browser console is clear of 429 errors.